### PR TITLE
feat: expand worldview network coverage

### DIFF
--- a/src/components/DoomRiver.tsx
+++ b/src/components/DoomRiver.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 import type { NavigationItem } from '../App';
 import { archiveEdges, archiveNodes, characterEchoNames, flowCards, museumHalls, riverStages, timelineEvents } from '../archiveData';
-import { getCharacterHallGroups } from '../characterHall';
 
 type DoomRiverProps = {
   activeView: NavigationItem;
@@ -138,9 +137,6 @@ export function DoomRiver({ activeView, onNavigate }: DoomRiverProps) {
     return () => observer.disconnect();
   }, [activeView]);
   const characterNodes = archiveNodes.filter((node) => node.type === 'character');
-  const { mainBoardIds, collapsedIds } = getCharacterHallGroups(archiveNodes);
-  const mainCharacterNodes = characterNodes.filter((node) => mainBoardIds.includes(node.id));
-  const collapsedCharacterNodes = characterNodes.filter((node) => collapsedIds.includes(node.id));
   const eventNodes = archiveNodes.filter((node) => node.type === 'event');
   const ruleNodes = archiveNodes.filter((node) => node.type === 'rule');
   const factionNodes = archiveNodes.filter((node) => node.type === 'faction');
@@ -364,7 +360,7 @@ export function DoomRiver({ activeView, onNavigate }: DoomRiverProps) {
 
   const [nodePositions, setNodePositions] = useState<Record<string, Point>>(() => buildInitialNodePositions());
 
-  const characterNetworkNodes = mainCharacterNodes.map((character) => {
+  const characterNetworkNodes = characterNodes.map((character) => {
     const position = nodePositions[character.id] ?? toPoint(120, 120);
     return {
       character,
@@ -546,7 +542,6 @@ export function DoomRiver({ activeView, onNavigate }: DoomRiverProps) {
         ['rule', 'truth', 'faction'].includes(targetType ?? '')
       );
     })
-    .slice(0, 10)
     .map((edge) => ({
       id: `${edge.source}-${edge.target}`,
       label: edge.label,
@@ -1143,22 +1138,6 @@ export function DoomRiver({ activeView, onNavigate }: DoomRiverProps) {
                   </div>
                 </article>
               ))}
-            </section>
-
-            <section className="museum-home__collapsed-characters" aria-labelledby="collapsed-character-heading">
-              <div className="museum-home__section-heading museum-home__section-heading--compact">
-                <p className="eyebrow">MORE / COLLAPSED</p>
-                <h3 id="collapsed-character-heading">更多人物折叠层</h3>
-              </div>
-              <div className="museum-home__collapsed-characters-grid">
-                {collapsedCharacterNodes.map((character) => (
-                  <article key={character.id} className="museum-home__collapsed-character-card">
-                    <p className="museum-home__dossier-range">回响：{toEchoName(character.id)}</p>
-                    <h4>{character.title}</h4>
-                    <p>{character.summary}</p>
-                  </article>
-                ))}
-              </div>
             </section>
         </section>
       ) : null}

--- a/src/worldview-hall.test.tsx
+++ b/src/worldview-hall.test.tsx
@@ -30,4 +30,13 @@ describe('Worldview hall', () => {
     expect(hall).toHaveTextContent('权力分层');
     expect(hall).toHaveTextContent('终局回收');
   });
+
+  it('renders the worldview network without truncating the connections', () => {
+    render(<App initialView="世界观馆" />);
+
+    const hall = screen.getByTestId('world-hall');
+    const networkNodes = hall.querySelectorAll('.museum-home__world-network-node');
+
+    expect(networkNodes.length).toBeGreaterThan(10);
+  });
 });


### PR DESCRIPTION
Closes #3\n\n- remove the 10-item cap from worldview connections\n- keep worldview classification focused on the four macro categories\n- guard against truncation in regression tests